### PR TITLE
Rev commons-validator version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This addresses a potential security concern as the previous version
commons-validator included a vulnerable version of commons-beanutils

https://ossindex.sonatype.org/component/pkg:maven/commons-beanutils/commons-beanutils@1.9.2?utm_source=ossindex-client&utm_

Given that most folks use this library for testing it's probably not
hugely concerning but seems worth a minor version bump :-)